### PR TITLE
Load Yoto library for card titles

### DIFF
--- a/desktop_ui/coordinator.py
+++ b/desktop_ui/coordinator.py
@@ -32,6 +32,8 @@ class DesktopCoordinator(QObject):
                 self.api_client = YotoAPIClient()
                 if self.api_client.authenticate(username, password):
                     self._is_authenticated = True
+                    # Preload library for card titles
+                    self.api_client.get_library()
                     # Connect to state changes for automatic UI updates
                     self.api_client.add_state_callback(self._on_state_change)
                     logger.info("Coordinator initialized with MQTT state monitoring")


### PR DESCRIPTION
## Summary
- cache card library in `YotoAPIClient`
- load library on coordinator startup so MQTT can look up real card titles

## Testing
- `python -m py_compile core/api_client.py desktop_ui/coordinator.py`
- `python coordinator_test.py` *(fails: Authentication error)*
- `python phase1_test.py` *(fails: Authentication error)*

------
https://chatgpt.com/codex/tasks/task_b_68791a3b9774833290c581d138db6198