### PR TITLE
Fix transport buttons

### DIFF
--- a/core/api_client.py
+++ b/core/api_client.py
@@ -78,6 +78,44 @@ class YotoAPIClient:
             logger.info("Playback paused on device %s", device_id)
         except Exception as exc:
             logger.error("Failed to pause playback: %s", exc)
+
+    def resume(self) -> None:
+        """Resume playback on the current device using yoto_api."""
+        if not self.manager:
+            logger.error("YotoManager not initialized")
+            return
+        device_id = os.getenv("YOTO_DEVICE_ID")
+        if not device_id:
+            logger.error("YOTO_DEVICE_ID environment variable not set")
+            return
+        player = self.manager.players.get(device_id)
+        if not player:
+            logger.error("Device %s not found", device_id)
+            return
+        try:
+            self.manager.resume_player(device_id)
+            logger.info("Playback resumed on device %s", device_id)
+        except Exception as exc:
+            logger.error("Failed to resume playback: %s", exc)
+
+    def stop(self) -> None:
+        """Stop playback on the current device using yoto_api."""
+        if not self.manager:
+            logger.error("YotoManager not initialized")
+            return
+        device_id = os.getenv("YOTO_DEVICE_ID")
+        if not device_id:
+            logger.error("YOTO_DEVICE_ID environment variable not set")
+            return
+        player = self.manager.players.get(device_id)
+        if not player:
+            logger.error("Device %s not found", device_id)
+            return
+        try:
+            self.manager.stop_player(device_id)
+            logger.info("Playback stopped on device %s", device_id)
+        except Exception as exc:
+            logger.error("Failed to stop playback: %s", exc)
     """Wrapper around ``yoto_api`` providing the old client interface."""
 
     def __init__(self, cache_dir: Optional[Path] = None) -> None:

--- a/desktop_ui/coordinator.py
+++ b/desktop_ui/coordinator.py
@@ -232,6 +232,46 @@ class DesktopCoordinator(QObject):
         except Exception as e:
             logger.error(f"Error getting chapters for {card_id}: {e}")
             return []
+
+    # ------------------------------------------------------------------
+    # Transport control slots
+    # ------------------------------------------------------------------
+    @Slot()
+    def play(self) -> None:
+        if self.api_client:
+            self.api_client.play()
+
+    @Slot()
+    def pause(self) -> None:
+        if self.api_client:
+            self.api_client.pause()
+
+    @Slot()
+    def resume(self) -> None:
+        if self.api_client:
+            self.api_client.resume()
+
+    @Slot()
+    def stop(self) -> None:
+        if self.api_client:
+            self.api_client.stop()
+
+    @Slot()
+    def toggle_play_pause(self) -> None:
+        if not self.api_client:
+            return
+        if self.api_client.playback_status == "playing":
+            self.api_client.pause()
+        else:
+            self.api_client.play()
+
+    @Slot()
+    def next_track(self) -> None:
+        logger.info("Next track requested - not implemented")
+
+    @Slot()
+    def previous_track(self) -> None:
+        logger.info("Previous track requested - not implemented")
     
     def cleanup(self) -> None:
         """Clean shutdown of coordinator"""

--- a/desktop_ui/qml/DetailView.qml
+++ b/desktop_ui/qml/DetailView.qml
@@ -238,7 +238,7 @@ Item {
                     }
                     
                     onClicked: {
-                        console.log("Previous chapter clicked")
+                        coordinator.previous_track()
                     }
                 }
                 
@@ -294,9 +294,7 @@ Item {
                     }
                     
                     onClicked: {
-                        console.log("Play/Pause clicked - coordinator state:", coordinator.playbackStatus)
-                        
-                        // Navigate to Now Playing screen when clicked
+                        coordinator.toggle_play_pause()
                         if (window.selectedCard) {
                             var stackView = root.parent
                             if (stackView) {
@@ -353,7 +351,7 @@ Item {
                     }
                     
                     onClicked: {
-                        console.log("Next chapter clicked")
+                        coordinator.next_track()
                     }
                 }
             }

--- a/desktop_ui/qml/NowPlayingView.qml
+++ b/desktop_ui/qml/NowPlayingView.qml
@@ -260,7 +260,7 @@ Item {
                     }
                     
                     onClicked: {
-                        console.log("Previous chapter clicked")
+                        coordinator.previous_track()
                     }
                 }
                 
@@ -316,8 +316,7 @@ Item {
                     }
                     
                     onClicked: {
-                        console.log("Play/Pause clicked - coordinator state:", coordinator.playbackStatus)
-                        // For now just log - actual device control can be added later
+                        coordinator.toggle_play_pause()
                     }
                 }
                 
@@ -359,7 +358,7 @@ Item {
                     }
                     
                     onClicked: {
-                        console.log("Next chapter clicked")
+                        coordinator.next_track()
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add resume and stop helpers in `YotoAPIClient`
- expose transport control slots from `DesktopCoordinator`
- wire Now Playing & Detail view buttons to coordinator slots

## Testing
- `python -m py_compile core/api_client.py desktop_ui/coordinator.py`
- `python coordinator_test.py` *(fails: AttributeError due to missing credentials)*
- `python phase1_test.py` *(fails: Authentication failed)*

------
https://chatgpt.com/codex/tasks/task_b_687951e6549483328f80422b4026e6bd