### PR TITLE
Add debug logs for MQTT state transitions

### DIFF
--- a/core/api_client.py
+++ b/core/api_client.py
@@ -152,6 +152,12 @@ class YotoAPIClient:
             self._state_callbacks.remove(callback)
 
     def _notify_state_change(self) -> None:
+        logger.debug(
+            "Notifying %d callbacks: status=%s card=%s",
+            len(self._state_callbacks),
+            self.playback_status,
+            self.active_card_id,
+        )
         for callback in self._state_callbacks:
             try:
                 callback()
@@ -189,6 +195,7 @@ class YotoAPIClient:
             }
 
     def _on_event(self) -> None:
+        logger.debug("MQTT event received - updating state")
         self._update_state_from_player()
         self._notify_state_change()
 
@@ -203,6 +210,13 @@ class YotoAPIClient:
         if not player:
             logger.error("Device %s not found", device_id)
             return
+        logger.debug(
+            "Player update: online=%s status=%s is_playing=%s card=%s",
+            player.online,
+            player.playback_status,
+            getattr(player, "is_playing", None),
+            player.card_id,
+        )
 
         self.playback_status = player.playback_status or (
             "playing" if player.is_playing else "stopped"
@@ -216,6 +230,13 @@ class YotoAPIClient:
             self.current_card_title = self._get_card_title(player.card_id)
         else:
             self.current_card_title = None
+        logger.debug(
+            "Updated state: status=%s card=%s position=%s/%s",
+            self.playback_status,
+            self.active_card_id,
+            self.track_position,
+            self.track_length,
+        )
 
     # ------------------------------------------------------------------
     @property

--- a/desktop_ui/coordinator.py
+++ b/desktop_ui/coordinator.py
@@ -33,6 +33,10 @@ class DesktopCoordinator(QObject):
         try:
             username = os.getenv("YOTO_USERNAME")
             password = os.getenv("YOTO_PASSWORD")
+            device_id = os.getenv("YOTO_DEVICE_ID")
+            logger.debug(
+                "Init credentials: username=%s device_id=%s", bool(username), device_id
+            )
             
             if username and password:
                 self.api_client = YotoAPIClient()
@@ -55,9 +59,15 @@ class DesktopCoordinator(QObject):
         if not self.api_client:
             return
         status = self.api_client.playback_status
+        card = getattr(self.api_client, "active_card_id", None)
         if status not in ["playing", "paused", "stopped"]:
             logger.warning(f"Unexpected playback status for further scope: {status}")
-        logger.debug(f"State change: status={status}, card={getattr(self.api_client, 'active_card_id', None)}")
+        logger.debug(
+            "State change: status=%s card=%s now_playing=%s",
+            status,
+            card,
+            bool(card),
+        )
         self.playbackStateChanged.emit()
         self.activeCardChanged.emit()
 
@@ -81,7 +91,13 @@ class DesktopCoordinator(QObject):
         """True if there's an active card (playing or paused)"""
         if not self.api_client:
             return False
-        return self.api_client.active_card_id is not None
+        value = self.api_client.active_card_id is not None
+        logger.debug(
+            "showNowPlaying property -> %s (card=%s)",
+            value,
+            self.api_client.active_card_id,
+        )
+        return value
 
     @Property(bool, notify=activeCardChanged)
     def hasActiveContent(self) -> bool:


### PR DESCRIPTION
## Summary
- improve debug logging in `core.api_client` and `desktop_ui.coordinator`
- log MQTT events, player updates, and computed property values

## Testing
- `python -m pytest -q` *(fails: Authentication error)*

------
https://chatgpt.com/codex/tasks/task_b_687964646af083329abfc671233e583b