### PR TITLE
Add device control coordinator

### DIFF
--- a/core/data_models.py
+++ b/core/data_models.py
@@ -8,6 +8,19 @@ from typing import Optional
 
 
 @dataclass
+class DeviceState:
+    """Realtime status values for a single Yoto player."""
+
+    playback_status: str = "stopped"
+    card_id: Optional[str] = None
+    volume: int = 0
+    battery: Optional[int] = None
+    wifi_strength: Optional[int] = None
+    temperature: Optional[float] = None
+    ambient_light: Optional[int] = None
+
+
+@dataclass
 class Card:
     """Represents a Yoto audio card with artwork caching support."""
     id: str


### PR DESCRIPTION
## Summary
- extend `DeviceState` with device sensor metrics
- manage token refresh and status polling
- add volume, brightness, light, time and alarm controls

## Testing
- `python coordinator_test.py` *(fails: certificate verify failed)*
- `python phase1_test.py` *(fails: certificate verify failed)*
- `python -m pylint yotobackend/client.py --errors-only`

------
https://chatgpt.com/codex/tasks/task_b_687968bc57c88332b5b91c1343f6294f