### PR TITLE
Add chapter navigation support

### DIFF
--- a/desktop_ui/coordinator.py
+++ b/desktop_ui/coordinator.py
@@ -313,11 +313,13 @@ class DesktopCoordinator(QObject):
 
     @Slot()
     def next_track(self) -> None:
-        logger.info("Next track requested - not implemented")
+        if self.api_client:
+            self.api_client.next_track()
 
     @Slot()
     def previous_track(self) -> None:
-        logger.info("Previous track requested - not implemented")
+        if self.api_client:
+            self.api_client.previous_track()
 
     def cleanup(self) -> None:
         """Clean shutdown of coordinator"""


### PR DESCRIPTION
## Summary
- implement next/previous track support in `core.api_client`
- wire up chapter skip buttons via `desktop_ui.coordinator`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687970727750832b8c68dd68ac33d3c9