### PR TITLE
Enable playing library cards

### DIFF
--- a/desktop_ui/coordinator.py
+++ b/desktop_ui/coordinator.py
@@ -343,6 +343,15 @@ class DesktopCoordinator(QObject):
         else:
             self.api_client.play()
 
+    @Slot(str, int)
+    def play_card(self, card_id: str, chapter: int = 1) -> None:
+        """Play a library card on the player."""
+        logger.info("Play card request: %s chapter %s", card_id, chapter)
+        if self.api_client:
+            self.api_client.play_card(card_id, chapter)
+        else:
+            logger.warning("Play card requested but API client not initialized")
+
     @Slot()
     def next_track(self) -> None:
         logger.info("Next track requested")

--- a/desktop_ui/qml/DetailView.qml
+++ b/desktop_ui/qml/DetailView.qml
@@ -294,7 +294,6 @@ Item {
                     }
                     
                     onClicked: {
-                        coordinator.toggle_play_pause()
                         if (window.selectedCard) {
                             var stackView = root.parent
                             if (stackView) {
@@ -304,6 +303,13 @@ Item {
                                     "cardImagePath": window.selectedCard.imagePath
                                 })
                             }
+                            if (!coordinator.isPlaying || coordinator.activeCardId !== window.selectedCard.cardId) {
+                                coordinator.play_card(window.selectedCard.cardId, 1)
+                            } else {
+                                coordinator.toggle_play_pause()
+                            }
+                        } else {
+                            coordinator.toggle_play_pause()
                         }
                     }
                 }

--- a/desktop_ui/qml/NowPlayingView.qml
+++ b/desktop_ui/qml/NowPlayingView.qml
@@ -340,7 +340,12 @@ Item {
                     }
                     
                     onClicked: {
-                        coordinator.toggle_play_pause()
+                        if (coordinator.isPlaying && coordinator.activeCardId === root.cardId) {
+                            coordinator.toggle_play_pause()
+                        } else {
+                            var chap = currentChapter ? currentChapter.key : 1
+                            coordinator.play_card(root.cardId, parseInt(chap))
+                        }
                     }
                 }
                 


### PR DESCRIPTION
## Summary
- add `play_card` method to `YotoAPIClient`
- expose `play_card` slot on coordinator
- auto-start card playback in QML views

## Testing
- `python -m pylint core/api_client.py --errors-only`


------
https://chatgpt.com/codex/tasks/task_b_6879a25b2a808332b7a4582d7e8d5da3